### PR TITLE
feat: UX improvements — placeholder defaults, auto-lock, group resets…

### DIFF
--- a/src/components/AfterTripForm.tsx
+++ b/src/components/AfterTripForm.tsx
@@ -11,8 +11,9 @@
  *  5. Extra Costs       — tolls, food, parking, etc.
  */
 
+import { useState } from 'react'
 import { Car, MapPin, Fuel, Home, ReceiptText, Info } from 'lucide-react'
-import { useCalculatorStore } from '../store/calculatorStore'
+import { useCalculatorStore, defaultAfterTrip } from '../store/calculatorStore'
 import { SectionCard } from './ui/SectionCard'
 import { InputField } from './ui/InputField'
 import { Toggle } from './ui/Toggle'
@@ -22,11 +23,41 @@ import { formatCurrency, formatLitres } from '../utils/formatters'
 
 function ActualTripSection() {
   const { afterTrip, updateAfterTrip } = useCalculatorStore()
+  const [totalDistanceLocked, setTotalDistanceLocked] = useState(true)
 
   const returnDistanceKm = Math.max(0, afterTrip.actualDistanceTotalKm - afterTrip.distanceToStationKm)
 
+  function handleDistanceToStationChange(v: number) {
+    if (totalDistanceLocked) {
+      updateAfterTrip({ distanceToStationKm: v, actualDistanceTotalKm: v * 2 })
+    } else {
+      updateAfterTrip({ distanceToStationKm: v })
+    }
+  }
+
+  function handleTotalDistanceChange(v: number) {
+    if (v === 0) {
+      setTotalDistanceLocked(true)
+      updateAfterTrip({ actualDistanceTotalKm: afterTrip.distanceToStationKm * 2 })
+    } else {
+      setTotalDistanceLocked(false)
+      updateAfterTrip({ actualDistanceTotalKm: v })
+    }
+  }
+
+  function handleReset() {
+    setTotalDistanceLocked(true)
+    updateAfterTrip({
+      actualConsumptionL100km: defaultAfterTrip.actualConsumptionL100km,
+      vehicleCostPerKm: defaultAfterTrip.vehicleCostPerKm,
+      includeVehicleWear: defaultAfterTrip.includeVehicleWear,
+      distanceToStationKm: defaultAfterTrip.distanceToStationKm,
+      actualDistanceTotalKm: defaultAfterTrip.actualDistanceTotalKm,
+    })
+  }
+
   return (
-    <SectionCard title="Actual Trip Data" icon={Car} accent="blue">
+    <SectionCard title="Actual Trip Data" icon={Car} accent="blue" onReset={handleReset}>
       <InputField
         label="Actual Consumption"
         value={afterTrip.actualConsumptionL100km}
@@ -43,7 +74,7 @@ function ActualTripSection() {
         <InputField
           label="Distance to Station"
           value={afterTrip.distanceToStationKm}
-          onChange={(v) => updateAfterTrip({ distanceToStationKm: v })}
+          onChange={handleDistanceToStationChange}
           unit="km"
           placeholder="30"
           min={0}
@@ -56,14 +87,20 @@ function ActualTripSection() {
         <InputField
           label="Total Actual Distance"
           value={afterTrip.actualDistanceTotalKm}
-          onChange={(v) => updateAfterTrip({ actualDistanceTotalKm: v })}
+          onChange={handleTotalDistanceChange}
+          onUnlock={() => setTotalDistanceLocked(false)}
           unit="km"
           placeholder="60"
           min={0}
           step={0.5}
-          hint="Full round-trip distance actually driven (odometer)"
+          locked={totalDistanceLocked}
+          hint={
+            totalDistanceLocked
+              ? `Auto: ${afterTrip.distanceToStationKm * 2} km — click to override`
+              : 'Full round-trip distance actually driven (odometer)'
+          }
         />
-        {returnDistanceKm > 0 && (
+        {!totalDistanceLocked && returnDistanceKm > 0 && (
           <p className="text-xs text-gray-400 dark:text-gray-500">
             Return leg: {returnDistanceKm.toFixed(1)} km
           </p>
@@ -102,8 +139,16 @@ function TankStateSection() {
   const fuelAtDepartureL = (afterTrip.tankLevelAtDeparturePercent / 100) * afterTrip.tankCapacityL
   const fuelAfterReturnL = (afterTrip.tankLevelAfterReturnPercent / 100) * afterTrip.tankCapacityL
 
+  function handleReset() {
+    updateAfterTrip({
+      tankCapacityL: defaultAfterTrip.tankCapacityL,
+      tankLevelAtDeparturePercent: defaultAfterTrip.tankLevelAtDeparturePercent,
+      tankLevelAfterReturnPercent: defaultAfterTrip.tankLevelAfterReturnPercent,
+    })
+  }
+
   return (
-    <SectionCard title="Tank State" icon={MapPin} accent="brand">
+    <SectionCard title="Tank State" icon={MapPin} accent="brand" onReset={handleReset}>
       <InputField
         label="Tank Capacity"
         value={afterTrip.tankCapacityL}
@@ -168,24 +213,130 @@ function TankStateSection() {
 }
 
 // ─── Section 3: Fuel Purchased Abroad ─────────────────────────────────────────
+//
+// Bidirectional auto-calc within: litersFilled, foreignPricePerL, totalPaidForeign
+// When n-1 of the 3 fields are filled, the remaining one is auto-calculated & locked.
+// Clearing any field in the group unlocks all fields.
+
+type FuelAbroadLocked = 'litersFilled' | 'foreignPricePerL' | 'totalPaidForeign' | null
 
 function FuelAbroadSection() {
   const { afterTrip, updateAfterTrip, currency } = useCalculatorStore()
+  const [lockedField, setLockedField] = useState<FuelAbroadLocked>(null)
 
   const totalForeignFuelL = afterTrip.litersFilled + afterTrip.extraCanisterLiters
-  const calculatedCost = totalForeignFuelL * afterTrip.foreignPricePerL
+
+  /** Unlock: clear the locked field value and set lockedField to null */
+  function unlock(extraUpdates: Partial<typeof afterTrip> = {}) {
+    const clearLocked: Partial<typeof afterTrip> = {}
+    if (lockedField === 'totalPaidForeign') {
+      clearLocked.totalPaidForeign = 0
+      clearLocked.useTotalPaidForeign = false
+    } else if (lockedField === 'foreignPricePerL') {
+      clearLocked.foreignPricePerL = 0
+    } else if (lockedField === 'litersFilled') {
+      clearLocked.litersFilled = 0
+    }
+    updateAfterTrip({ ...clearLocked, ...extraUpdates })
+    setLockedField(null)
+  }
+
+  function handleLitersChange(v: number) {
+    const p = afterTrip.foreignPricePerL
+    const t = afterTrip.totalPaidForeign
+
+    if (v === 0) {
+      // Clearing this field → unlock everything
+      unlock({ litersFilled: 0 })
+      return
+    }
+
+    if (lockedField === 'totalPaidForeign' && p > 0) {
+      updateAfterTrip({ litersFilled: v, totalPaidForeign: v * p, useTotalPaidForeign: true })
+    } else if (lockedField === 'foreignPricePerL' && t > 0) {
+      updateAfterTrip({ litersFilled: v, foreignPricePerL: t / v })
+    } else if (lockedField === null && p > 0 && t === 0) {
+      updateAfterTrip({ litersFilled: v, totalPaidForeign: v * p, useTotalPaidForeign: true })
+      setLockedField('totalPaidForeign')
+    } else if (lockedField === null && t > 0 && p === 0) {
+      updateAfterTrip({ litersFilled: v, foreignPricePerL: t / v })
+      setLockedField('foreignPricePerL')
+    } else {
+      updateAfterTrip({ litersFilled: v })
+    }
+  }
+
+  function handlePriceChange(v: number) {
+    const l = afterTrip.litersFilled
+    const t = afterTrip.totalPaidForeign
+
+    if (v === 0) {
+      unlock({ foreignPricePerL: 0 })
+      return
+    }
+
+    if (lockedField === 'totalPaidForeign' && l > 0) {
+      updateAfterTrip({ foreignPricePerL: v, totalPaidForeign: l * v, useTotalPaidForeign: true })
+    } else if (lockedField === 'litersFilled' && t > 0) {
+      updateAfterTrip({ foreignPricePerL: v, litersFilled: t / v })
+    } else if (lockedField === null && l > 0 && t === 0) {
+      updateAfterTrip({ foreignPricePerL: v, totalPaidForeign: l * v, useTotalPaidForeign: true })
+      setLockedField('totalPaidForeign')
+    } else if (lockedField === null && t > 0 && l === 0) {
+      updateAfterTrip({ foreignPricePerL: v, litersFilled: t / v })
+      setLockedField('litersFilled')
+    } else {
+      updateAfterTrip({ foreignPricePerL: v })
+    }
+  }
+
+  function handleTotalPaidChange(v: number) {
+    const l = afterTrip.litersFilled
+    const p = afterTrip.foreignPricePerL
+
+    if (v === 0) {
+      unlock({ totalPaidForeign: 0, useTotalPaidForeign: false })
+      return
+    }
+
+    if (lockedField === 'foreignPricePerL' && l > 0) {
+      updateAfterTrip({ totalPaidForeign: v, foreignPricePerL: v / l, useTotalPaidForeign: true })
+    } else if (lockedField === 'litersFilled' && p > 0) {
+      updateAfterTrip({ totalPaidForeign: v, litersFilled: v / p, useTotalPaidForeign: true })
+    } else if (lockedField === null && l > 0 && p === 0) {
+      updateAfterTrip({ totalPaidForeign: v, foreignPricePerL: v / l, useTotalPaidForeign: true })
+      setLockedField('foreignPricePerL')
+    } else if (lockedField === null && p > 0 && l === 0) {
+      updateAfterTrip({ totalPaidForeign: v, litersFilled: v / p, useTotalPaidForeign: true })
+      setLockedField('litersFilled')
+    } else {
+      updateAfterTrip({ totalPaidForeign: v, useTotalPaidForeign: true })
+    }
+  }
+
+  function handleReset() {
+    setLockedField(null)
+    updateAfterTrip({
+      litersFilled: defaultAfterTrip.litersFilled,
+      extraCanisterLiters: defaultAfterTrip.extraCanisterLiters,
+      foreignPricePerL: defaultAfterTrip.foreignPricePerL,
+      totalPaidForeign: defaultAfterTrip.totalPaidForeign,
+      useTotalPaidForeign: defaultAfterTrip.useTotalPaidForeign,
+    })
+  }
 
   return (
-    <SectionCard title="Fuel Purchased Abroad" icon={Fuel} accent="amber">
+    <SectionCard title="Fuel Purchased Abroad" icon={Fuel} accent="amber" onReset={handleReset}>
       {/* Quantity */}
       <InputField
         label="Litres Filled (Tank)"
         value={afterTrip.litersFilled}
-        onChange={(v) => updateAfterTrip({ litersFilled: v })}
+        onChange={handleLitersChange}
         unit="L"
         placeholder="40"
         min={0}
         step={0.5}
+        locked={lockedField === 'litersFilled'}
         hint="Litres pumped into the vehicle tank"
       />
       <div className="flex flex-col gap-1">
@@ -210,39 +361,41 @@ function FuelAbroadSection() {
       <InputField
         label="Foreign Price per Litre"
         value={afterTrip.foreignPricePerL}
-        onChange={(v) => updateAfterTrip({ foreignPricePerL: v })}
+        onChange={handlePriceChange}
         unit={`${currency}/L`}
         placeholder="1.35"
         min={0}
         step={0.001}
+        locked={lockedField === 'foreignPricePerL'}
         hint="Pump price at the foreign station"
       />
 
-      {/* Total paid toggle */}
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-col gap-1">
-          <InputField
-            label="Total Paid (Receipt)"
-            value={afterTrip.totalPaidForeign}
-            onChange={(v) => updateAfterTrip({ totalPaidForeign: v })}
-            unit={currency}
-            placeholder={calculatedCost > 0 ? calculatedCost.toFixed(2) : '0'}
-            min={0}
-            step={0.01}
-            disabled={!afterTrip.useTotalPaidForeign}
-            hint={
-              afterTrip.useTotalPaidForeign
-                ? 'Actual amount from your receipt'
-                : `Calculated: ${formatCurrency(calculatedCost, currency)}`
-            }
+      {/* Total paid */}
+      <InputField
+        label="Total Paid (Receipt)"
+        value={afterTrip.totalPaidForeign}
+        onChange={handleTotalPaidChange}
+        unit={currency}
+        placeholder="0"
+        min={0}
+        step={0.01}
+        locked={lockedField === 'totalPaidForeign'}
+        hint={
+          lockedField === 'totalPaidForeign'
+            ? 'Auto-calculated — clear a sibling field to override'
+            : 'Enter receipt total to auto-derive missing field'
+        }
+      />
+
+      {lockedField === null && (
+        <div className="sm:col-span-2">
+          <Toggle
+            checked={afterTrip.useTotalPaidForeign}
+            onChange={(v) => updateAfterTrip({ useTotalPaidForeign: v })}
+            label="Use actual receipt total"
           />
         </div>
-        <Toggle
-          checked={afterTrip.useTotalPaidForeign}
-          onChange={(v) => updateAfterTrip({ useTotalPaidForeign: v })}
-          label="Use actual receipt total"
-        />
-      </div>
+      )}
     </SectionCard>
   )
 }
@@ -256,8 +409,12 @@ function DomesticBaselineSection() {
   const domesticEquivalent = totalForeignFuelL * afterTrip.homePricePerL
   const priceDiff = afterTrip.homePricePerL - afterTrip.foreignPricePerL
 
+  function handleReset() {
+    updateAfterTrip({ homePricePerL: defaultAfterTrip.homePricePerL })
+  }
+
   return (
-    <SectionCard title="Domestic Baseline" icon={Home} accent="brand">
+    <SectionCard title="Domestic Baseline" icon={Home} accent="brand" onReset={handleReset}>
       <div className="sm:col-span-2 flex flex-col gap-3">
         <div className="flex flex-col gap-1">
           <InputField
@@ -318,8 +475,19 @@ function AfterTripExtraCostsSection() {
     afterTrip.currencyExchangeFee +
     afterTrip.miscCost
 
+  function handleReset() {
+    updateAfterTrip({
+      tollCost: 0,
+      parkingCost: 0,
+      foodCost: 0,
+      restroomCost: 0,
+      currencyExchangeFee: 0,
+      miscCost: 0,
+    })
+  }
+
   return (
-    <SectionCard title="Extra Costs" icon={ReceiptText} accent="purple">
+    <SectionCard title="Extra Costs" icon={ReceiptText} accent="purple" onReset={handleReset}>
       <InputField
         label="Toll"
         value={afterTrip.tollCost}

--- a/src/components/ExtraCostsForm.tsx
+++ b/src/components/ExtraCostsForm.tsx
@@ -3,7 +3,7 @@
  */
 
 import { ReceiptText } from 'lucide-react'
-import { useCalculatorStore } from '../store/calculatorStore'
+import { useCalculatorStore, defaultExtraCosts } from '../store/calculatorStore'
 import { SectionCard } from './ui/SectionCard'
 import { InputField } from './ui/InputField'
 import { formatCurrency } from '../utils/formatters'
@@ -19,8 +19,12 @@ export function ExtraCostsForm() {
     extraCosts.currencyExchangeFee +
     extraCosts.miscCost
 
+  function handleReset() {
+    updateExtraCosts(defaultExtraCosts)
+  }
+
   return (
-    <SectionCard title="Extra Costs" icon={ReceiptText} accent="purple">
+    <SectionCard title="Extra Costs" icon={ReceiptText} accent="purple" onReset={handleReset}>
       <InputField
         label="Toll"
         value={extraCosts.tollCost}

--- a/src/components/FuelForm.tsx
+++ b/src/components/FuelForm.tsx
@@ -3,7 +3,7 @@
  */
 
 import { Fuel } from 'lucide-react'
-import { useCalculatorStore } from '../store/calculatorStore'
+import { useCalculatorStore, defaultFuel } from '../store/calculatorStore'
 import { SectionCard } from './ui/SectionCard'
 import { InputField } from './ui/InputField'
 
@@ -13,8 +13,12 @@ export function FuelForm() {
   const priceDiff = fuel.homeFuelPricePerL - fuel.foreignFuelPricePerL
   const totalRefuel = fuel.litersToRefuelVehicle + fuel.extraCanisterLiters
 
+  function handleReset() {
+    updateFuel(defaultFuel)
+  }
+
   return (
-    <SectionCard title="Fuel" icon={Fuel} accent="amber">
+    <SectionCard title="Fuel" icon={Fuel} accent="amber" onReset={handleReset}>
       {/* Prices */}
       <InputField
         label="Home Fuel Price"

--- a/src/components/ResultsPanel.tsx
+++ b/src/components/ResultsPanel.tsx
@@ -12,7 +12,8 @@ import {
   formatDistance,
   formatPercent,
 } from '../utils/formatters'
-import type { AfterTripDetail } from '../types/calculatorTypes'
+import type { AfterTripDetail, TripCalculationResult } from '../types/calculatorTypes'
+import { Tooltip } from './ui/Tooltip'
 
 // ─── Individual stat tile ──────────────────────────────────────────────────────
 
@@ -22,9 +23,10 @@ interface StatTileProps {
   sub?: string
   positive?: boolean | null
   icon?: React.ReactNode
+  tooltip?: string
 }
 
-function StatTile({ label, value, sub, positive, icon }: StatTileProps) {
+function StatTile({ label, value, sub, positive, icon, tooltip }: StatTileProps) {
   const bg =
     positive === true
       ? 'bg-green-50 border-green-200 dark:bg-green-900/20 dark:border-green-700'
@@ -43,11 +45,50 @@ function StatTile({ label, value, sub, positive, icon }: StatTileProps) {
     <div className={`rounded-xl border-2 p-4 flex flex-col gap-1 ${bg}`}>
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">{label}</span>
-        {icon && <span className="text-gray-400 dark:text-gray-500">{icon}</span>}
+        <div className="flex items-center gap-1.5">
+          {tooltip && <Tooltip text={tooltip} wide />}
+          {icon && <span className="text-gray-400 dark:text-gray-500">{icon}</span>}
+        </div>
       </div>
       <span className={`text-xl font-bold ${valueColor}`}>{value}</span>
       {sub && <span className="text-xs text-gray-400 dark:text-gray-500">{sub}</span>}
     </div>
+  )
+}
+
+// ─── Formula tooltip builders ─────────────────────────────────────────────────
+
+function buildNetSavingsTooltip(trip: TripCalculationResult, currency: string): string {
+  return (
+    `Local Equivalent (${formatCurrency(trip.homeRefuelCost, currency)}) ` +
+    `− Paid Abroad (${formatCurrency(trip.foreignRefuelCost, currency)}) ` +
+    `− Trip Overhead (${formatCurrency(trip.tripTotalCost, currency)}) ` +
+    `= ${formatCurrency(trip.savings, currency)}`
+  )
+}
+
+function buildEffectivePriceTooltip(trip: TripCalculationResult, currency: string): string {
+  return (
+    `(Paid Abroad + Trip Overhead) ÷ Total Litres = ` +
+    `(${formatCurrency(trip.foreignRefuelCost, currency)} + ${formatCurrency(trip.tripTotalCost, currency)}) ` +
+    `÷ ${formatLitres(trip.totalRefuelLiters)} ` +
+    `= ${formatPricePerLitre(trip.effectivePricePerL, currency)}`
+  )
+}
+
+function buildRoiTooltip(trip: TripCalculationResult, currency: string): string {
+  return (
+    `Net Savings ÷ Paid Abroad × 100 = ` +
+    `${formatCurrency(trip.savings, currency)} ÷ ${formatCurrency(trip.foreignRefuelCost, currency)} × 100 ` +
+    `= ${formatPercent(trip.roiPercent)}`
+  )
+}
+
+function buildOverheadTooltip(trip: TripCalculationResult, currency: string): string {
+  return (
+    `Travel Fuel Cost + Vehicle Wear + Extra Costs = ` +
+    `${formatCurrency(trip.tripFuelCost, currency)} + ${formatCurrency(trip.vehicleCostTotal, currency)} + ${formatCurrency(trip.extraCostTotal, currency)} ` +
+    `= ${formatCurrency(trip.tripTotalCost, currency)}`
   )
 }
 
@@ -260,6 +301,7 @@ export function ResultsPanel() {
           }
           positive={isWorthIt ? true : false}
           icon={isWorthIt ? <TrendingUp size={16} /> : <TrendingDown size={16} />}
+          tooltip={buildNetSavingsTooltip(trip, currency)}
         />
         <StatTile
           label="Effective Price/L"
@@ -267,6 +309,7 @@ export function ResultsPanel() {
           sub="incl. all overhead"
           positive={null}
           icon={<Fuel size={16} />}
+          tooltip={buildEffectivePriceTooltip(trip, currency)}
         />
         <StatTile
           label="Trip ROI"
@@ -274,6 +317,7 @@ export function ResultsPanel() {
           sub="return on investment"
           positive={trip.roiPercent > 0 ? true : trip.roiPercent < 0 ? false : null}
           icon={<Gauge size={16} />}
+          tooltip={buildRoiTooltip(trip, currency)}
         />
         <StatTile
           label="Trip Overhead"
@@ -281,6 +325,7 @@ export function ResultsPanel() {
           sub={isAnalysis ? 'outbound fuel + extras + wear' : 'fuel + extras + wear'}
           positive={null}
           icon={<Route size={16} />}
+          tooltip={buildOverheadTooltip(trip, currency)}
         />
         <StatTile
           label={isAnalysis ? 'Fuel Consumed' : 'Trip Fuel Used'}

--- a/src/components/TripForm.tsx
+++ b/src/components/TripForm.tsx
@@ -3,15 +3,19 @@
  */
 
 import { MapPin } from 'lucide-react'
-import { useCalculatorStore } from '../store/calculatorStore'
+import { useCalculatorStore, defaultTrip } from '../store/calculatorStore'
 import { SectionCard } from './ui/SectionCard'
 import { InputField } from './ui/InputField'
 
 export function TripForm() {
   const { trip, updateTrip } = useCalculatorStore()
 
+  function handleReset() {
+    updateTrip(defaultTrip)
+  }
+
   return (
-    <SectionCard title="Trip" icon={MapPin} accent="blue">
+    <SectionCard title="Trip" icon={MapPin} accent="blue" onReset={handleReset}>
       <InputField
         label="Distance to Station"
         value={trip.distanceToForeignStationKm}

--- a/src/components/VehicleForm.tsx
+++ b/src/components/VehicleForm.tsx
@@ -3,7 +3,7 @@
  */
 
 import { Car } from 'lucide-react'
-import { useCalculatorStore } from '../store/calculatorStore'
+import { useCalculatorStore, defaultVehicle } from '../store/calculatorStore'
 import { SectionCard } from './ui/SectionCard'
 import { InputField } from './ui/InputField'
 import { Toggle } from './ui/Toggle'
@@ -11,8 +11,12 @@ import { Toggle } from './ui/Toggle'
 export function VehicleForm() {
   const { vehicle, updateVehicle } = useCalculatorStore()
 
+  function handleReset() {
+    updateVehicle(defaultVehicle)
+  }
+
   return (
-    <SectionCard title="Vehicle" icon={Car} accent="brand">
+    <SectionCard title="Vehicle" icon={Car} accent="brand" onReset={handleReset}>
       <InputField
         label="Avg. Consumption"
         value={vehicle.averageConsumptionL100km}

--- a/src/components/ui/InputField.tsx
+++ b/src/components/ui/InputField.tsx
@@ -1,8 +1,13 @@
 /**
  * Reusable labelled numeric input field.
+ *
+ * locked={true}   → readonly field, muted background, lock icon
+ * onUnlock        → if provided on a locked field, focusing it calls onUnlock
+ *                   to allow a "click to unlock" pattern (soft-lock UX)
  */
 
 import React from 'react'
+import { Lock } from 'lucide-react'
 
 interface InputFieldProps {
   label: string
@@ -15,6 +20,9 @@ interface InputFieldProps {
   step?: number
   hint?: string
   disabled?: boolean
+  locked?: boolean
+  /** Called when user focuses a locked field — parent can use this to unlock */
+  onUnlock?: () => void
   id?: string
 }
 
@@ -29,11 +37,14 @@ export function InputField({
   step = 0.01,
   hint,
   disabled = false,
+  locked = false,
+  onUnlock,
   id,
 }: InputFieldProps) {
   const fieldId = id ?? label.toLowerCase().replace(/\s+/g, '-')
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (locked) return
     const raw = e.target.value
     if (raw === '' || raw === '-') {
       onChange(0)
@@ -42,6 +53,12 @@ export function InputField({
     const parsed = parseFloat(raw.replace(',', '.'))
     if (!isNaN(parsed)) onChange(parsed)
   }
+
+  function handleFocus() {
+    if (locked && onUnlock) onUnlock()
+  }
+
+  const isInactive = disabled || locked
 
   return (
     <div className="flex flex-col gap-1">
@@ -54,25 +71,36 @@ export function InputField({
           type="number"
           value={value === 0 ? '' : value}
           onChange={handleChange}
+          onFocus={handleFocus}
           placeholder={placeholder}
           min={min}
           max={max}
           step={step}
-          disabled={disabled}
+          disabled={isInactive && !onUnlock}
+          readOnly={locked && !onUnlock}
           className={[
             'w-full rounded-lg border px-3 py-2 text-sm shadow-sm transition-colors',
             'focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent',
-            unit ? 'pr-12' : '',
-            disabled
+            unit || locked ? 'pr-12' : '',
+            locked
+              ? onUnlock
+                ? 'bg-slate-100 text-gray-600 border-slate-300 cursor-text dark:bg-slate-800 dark:text-gray-300 dark:border-slate-600'
+                : 'bg-slate-100 text-gray-600 border-slate-300 cursor-not-allowed dark:bg-slate-800 dark:text-gray-300 dark:border-slate-600'
+              : disabled
               ? 'bg-gray-50 text-gray-400 border-gray-200 cursor-not-allowed dark:bg-gray-800 dark:text-gray-500 dark:border-gray-700'
               : 'bg-white border-gray-300 text-gray-900 hover:border-gray-400 dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100 dark:hover:border-gray-500 dark:placeholder-gray-500',
           ].join(' ')}
         />
-        {unit && (
+        {locked ? (
+          <span className="absolute right-3 text-xs font-medium text-slate-400 dark:text-slate-500 pointer-events-none select-none flex items-center gap-1">
+            {unit && <span>{unit}</span>}
+            <Lock size={11} />
+          </span>
+        ) : unit ? (
           <span className="absolute right-3 text-xs font-medium text-gray-400 dark:text-gray-500 pointer-events-none select-none">
             {unit}
           </span>
-        )}
+        ) : null}
       </div>
       {hint && <p className="text-xs text-gray-400 dark:text-gray-500">{hint}</p>}
     </div>

--- a/src/components/ui/SectionCard.tsx
+++ b/src/components/ui/SectionCard.tsx
@@ -1,9 +1,10 @@
 /**
- * Card wrapper for form sections with title and optional icon.
+ * Card wrapper for form sections with title, optional icon, and optional group reset.
  */
 
 import React from 'react'
 import type { LucideIcon } from 'lucide-react'
+import { RotateCcw } from 'lucide-react'
 
 interface SectionCardProps {
   title: string
@@ -11,9 +12,10 @@ interface SectionCardProps {
   children: React.ReactNode
   className?: string
   accent?: string
+  onReset?: () => void
 }
 
-export function SectionCard({ title, icon: Icon, children, className = '', accent = 'brand' }: SectionCardProps) {
+export function SectionCard({ title, icon: Icon, children, className = '', accent = 'brand', onReset }: SectionCardProps) {
   const accentClasses: Record<string, string> = {
     brand: 'border-brand-200 bg-brand-50/30 dark:border-brand-700 dark:bg-brand-900/10',
     blue:  'border-blue-200 bg-blue-50/30 dark:border-blue-700 dark:bg-blue-900/10',
@@ -44,7 +46,18 @@ export function SectionCard({ title, icon: Icon, children, className = '', accen
             aria-hidden="true"
           />
         )}
-        <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100">{title}</h2>
+        <h2 className="text-base font-semibold text-gray-800 dark:text-gray-100 flex-1">{title}</h2>
+        {onReset && (
+          <button
+            type="button"
+            onClick={onReset}
+            title={`Reset ${title}`}
+            aria-label={`Reset ${title}`}
+            className="opacity-50 hover:opacity-100 focus:opacity-100 transition-opacity p-1 rounded text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+          >
+            <RotateCcw size={14} />
+          </button>
+        )}
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">{children}</div>
     </div>

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -1,34 +1,48 @@
 /**
- * Simple hover tooltip.
+ * Info tooltip — hover on desktop, tap-to-toggle on mobile.
+ * Shows an ⓘ icon; content appears above on hover/tap.
  */
 
 import { useState } from 'react'
-import { HelpCircle } from 'lucide-react'
+import { Info } from 'lucide-react'
 
 interface TooltipProps {
   text: string
+  wide?: boolean
 }
 
-export function Tooltip({ text }: TooltipProps) {
+export function Tooltip({ text, wide = false }: TooltipProps) {
   const [visible, setVisible] = useState(false)
+
+  function toggle(e: React.MouseEvent) {
+    e.stopPropagation()
+    setVisible((v) => !v)
+  }
 
   return (
     <span className="relative inline-flex items-center">
       <button
         type="button"
+        onClick={toggle}
         onMouseEnter={() => setVisible(true)}
         onMouseLeave={() => setVisible(false)}
         onFocus={() => setVisible(true)}
         onBlur={() => setVisible(false)}
         className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors"
-        aria-label="More information"
+        aria-label="Show formula"
+        aria-expanded={visible}
       >
-        <HelpCircle size={14} />
+        <Info size={14} />
       </button>
       {visible && (
-        <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-56 rounded-lg bg-gray-800 dark:bg-gray-900 px-3 py-2 text-xs text-white shadow-lg z-50 text-center leading-relaxed">
+        <span
+          className={[
+            'absolute bottom-full right-0 mb-2 rounded-lg bg-gray-800 dark:bg-gray-900 px-3 py-2 text-xs text-white shadow-lg z-50 leading-relaxed',
+            wide ? 'w-72' : 'w-56',
+          ].join(' ')}
+        >
           {text}
-          <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-800 dark:border-t-gray-900" />
+          <span className="absolute top-full right-3 border-4 border-transparent border-t-gray-800 dark:border-t-gray-900" />
         </span>
       )}
     </span>

--- a/src/store/calculatorStore.ts
+++ b/src/store/calculatorStore.ts
@@ -22,15 +22,15 @@ import { calculateBreakEven } from '../lib/breakEvenCalculations'
 
 // ─── Default values ────────────────────────────────────────────────────────────
 
-const defaultVehicle: VehicleData = {
+export const defaultVehicle: VehicleData = {
   averageConsumptionL100km: 7,
   tankCapacityL: 50,
   currentTankLevelPercent: 30,
-  vehicleCostPerKm: 0.08,
+  vehicleCostPerKm: 0,
   includeVehicleWear: false,
 }
 
-const defaultTrip: TripData = {
+export const defaultTrip: TripData = {
   distanceToForeignStationKm: 30,
   totalDistanceKm: 60,
   totalDistanceOverridden: false,
@@ -38,14 +38,14 @@ const defaultTrip: TripData = {
   borderWaitTimeMinutes: 0,
 }
 
-const defaultFuel: FuelData = {
+export const defaultFuel: FuelData = {
   homeFuelPricePerL: 1.65,
   foreignFuelPricePerL: 1.35,
   litersToRefuelVehicle: 40,
   extraCanisterLiters: 0,
 }
 
-const defaultExtraCosts: ExtraCosts = {
+export const defaultExtraCosts: ExtraCosts = {
   tollCost: 0,
   parkingCost: 0,
   foodCost: 0,
@@ -57,7 +57,7 @@ const defaultExtraCosts: ExtraCosts = {
 export const defaultAfterTrip: AfterTripData = {
   // Vehicle
   actualConsumptionL100km: 7,
-  vehicleCostPerKm: 0.08,
+  vehicleCostPerKm: 0,
   includeVehicleWear: false,
 
   // Trip distances


### PR DESCRIPTION
…, formula tooltips

Task 1 — Placeholder instead of pre-filled values
- Change vehicleCostPerKm default from 0.08 → 0 in both planning and analysis mode, so the field renders empty with 0.08 as grey placeholder text until the user explicitly types a value.

Task 2 — Bidirectional field calculation with auto-lock
- FuelAbroadSection: when 2 of {Litres Filled, Foreign Price/L, Total Paid} are filled the third is auto-calculated, rendered with a 🔒 lock icon and muted background (readonly). Clearing any field in the group unlocks all.
- ActualTripSection: Total Actual Distance auto-locks to Distance × 2; supports click-to-unlock (onUnlock prop) so the user can type directly without needing to clear a sibling first.
- InputField gains locked and onUnlock props; locked=true renders the field readonly with a slate background and a Lock icon in the unit slot.

Task 3 — Per-group reset button
- SectionCard gains an optional onReset prop that renders a subtle ↺ icon button (60% opacity, full on hover/focus) in the section header.
- All five AfterTripForm sections and all four planning-mode forms wire up onReset to restore that section's fields to their store defaults.

Task 4 — Formula tooltips on result cards
- StatTile gains a tooltip prop; clicking/hovering the ⓘ icon shows a popover with the formula and actual substituted numbers.
- Four cards have tooltips: Net Savings, Effective Price/L, Trip ROI, Trip Overhead.
- Tooltip component updated to use Info icon, support wide variant, and tap-to-toggle for mobile.

https://claude.ai/code/session_01FysZ4FHH9M7Ur4KGqU6YNh